### PR TITLE
Use containerd instead of Docker

### DIFF
--- a/manifests/bootstrap/init.pp
+++ b/manifests/bootstrap/init.pp
@@ -33,7 +33,7 @@ class protogalaxy::bootstrap::init (
       '--upload-certs',
       "--token ${discovery_token}",
       "--certificate-key ${certkey}",
-      "--apiserver-bind-port 16443",
+      '--apiserver-bind-port 16443',
       "--pod-network-cidr ${pod_cidr}",
       "--service-cidr ${service_cidr}"], ' '),
     creates => '/etc/kubernetes/kubelet.conf',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,9 +25,6 @@
 #   Version of the kubeadm, kubelet and kubectl packages to install,
 #   along with the control plane version. Defaults to 1.18.5.
 #
-# @param docker_version
-#   Version of docker to install. Defaults to 5:19.03.12~3-0~ubuntu-bionic.
-#
 # @param network_interface
 #   Specify the network interface where the other nodes are reachable.
 #   If this is your default interface, you may omit it.
@@ -61,7 +58,6 @@ class protogalaxy {
   $pod_cidr = lookup('protogalaxy::pod_cidr', String, first)
   $service_cidr = lookup('protogalaxy::service_cidr', String, first, '10.96.0.0/12')
   $k8s_version = lookup('protogalaxy::k8s_version', String, first, '1.19.2')
-  $docker_version = lookup('protogalaxy::docker_version', String, first, '5:19.03.13~3-0~ubuntu-bionic')
   $network_interface = lookup('protogalaxy::network_interface', Optional[String], first, undef)
   $keepalived_image = lookup('protogalaxy::keepalived_image', String, first, 'rkevin/keepalived:2.0.20')
   $haproxy_image = lookup('protogalaxy::haproxy_image', String, first, 'haproxy:2.2-alpine')

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -3,9 +3,6 @@
 # @param k8s_version
 #   Version of the kubeadm, kubelet and kubectl packages to install.
 #
-# @param docker_version
-#   Version of docker-ce to install.
-#
 # @param is_mgmt
 #   Whether this node should only install packages relavent to kubernetes management.
 #
@@ -15,12 +12,10 @@
 # @example
 #   include protogalaxy::packages {
 #     k8s_version => '1.18.5',
-#     docker_version => '5:19.03.12~3-0~ubuntu-bionic',
 #   }
 
 class protogalaxy::packages (
   String $k8s_version = $protogalaxy::k8s_version,
-  String $docker_version = $protogalaxy::docker_version,
   Boolean $is_mgmt = false,
   Boolean $upgrading_cluster = $protogalaxy::upgrading_cluster,
 ) inherits protogalaxy {
@@ -62,8 +57,8 @@ class protogalaxy::packages (
       unless   => "test -e /usr/local/bin/helm -a $(helm version --template '{{.Version}}') = ${latest_helm_version}",
     }
   } else {
-    package { 'docker-ce':
-      ensure  => $docker_version,
+    package { 'containerd.io':
+      ensure  => present,
       require => Class['Apt::Update'],
     }
     package { ['kubectl', 'kubeadm']:

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -1,4 +1,4 @@
-# @summary Class to ensure the docker service and kubelet service are always running
+# @summary Class to ensure the containerd service and kubelet service are always running
 #
 # @param upgrading_cluster
 #   If this boolean is true, do not enforce kubelet to be running.
@@ -11,16 +11,16 @@ class protogalaxy::services (
 ) inherits protogalaxy {
   include protogalaxy::packages
   require protogalaxy::disable_swap
-  service { 'docker':
+  service { 'containerd':
     ensure  => running,
     enable  => true,
-    require => Package['docker-ce'],
+    require => Package['containerd.io'],
   }
   service { 'kubelet':
     ensure  => running,
     enable  => true,
     require => [
-      Service['docker'],
+      Service['containerd'],
       $upgrading_cluster ? {
         true  => undef,
         false => Package['kubelet'],

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -20,10 +20,18 @@ class protogalaxy::services (
     value => 1,
   }
 
+  exec { 'ensure containerd does not disable cri':
+    command => 'rm /etc/containerd/config.toml',
+    onlyif  => 'grep \'disabled_plugins = \["cri"\]\' /etc/containerd/config.toml',
+  }
+
   service { 'containerd':
     ensure  => running,
     enable  => true,
-    require => Package['containerd.io'],
+    require => [
+      Package['containerd.io'],
+      Exec['ensure containerd does not disable cri'],
+    ]
   }
   service { 'kubelet':
     ensure  => running,

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -24,7 +24,7 @@ class protogalaxy::services (
     command  => 'rm /etc/containerd/config.toml',
     provider => shell,
     onlyif   => 'grep \'disabled_plugins = \["cri"\]\' /etc/containerd/config.toml',
-    notify   => service['containerd'],
+    notify   => Service['containerd'],
   }
 
   service { 'containerd':

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -11,6 +11,15 @@ class protogalaxy::services (
 ) inherits protogalaxy {
   include protogalaxy::packages
   require protogalaxy::disable_swap
+
+  kmod::load { 'br_netfilter':
+    ensure => present,
+  }
+
+  sysctl::value { 'net.ipv4.forward':
+    value => 1,
+  }
+
   service { 'containerd':
     ensure  => running,
     enable  => true,
@@ -26,6 +35,8 @@ class protogalaxy::services (
         false => Package['kubelet'],
       },
       Class['protogalaxy::disable_swap'],
+      kmod::load['br_netfilter'],
+      sysctl::value['net.ipv4.forward'],
     ],
   }
 }

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -21,18 +21,16 @@ class protogalaxy::services (
   }
 
   exec { 'ensure containerd does not disable cri':
-    command => 'rm /etc/containerd/config.toml',
+    command  => 'rm /etc/containerd/config.toml',
     provider => shell,
-    onlyif  => 'grep \'disabled_plugins = \["cri"\]\' /etc/containerd/config.toml',
+    onlyif   => 'grep \'disabled_plugins = \["cri"\]\' /etc/containerd/config.toml',
+    notify   => service['containerd'],
   }
 
   service { 'containerd':
     ensure  => running,
     enable  => true,
-    require => [
-      Package['containerd.io'],
-      Exec['ensure containerd does not disable cri'],
-    ]
+    require => Package['containerd.io'],
   }
   service { 'kubelet':
     ensure  => running,

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -16,7 +16,7 @@ class protogalaxy::services (
     ensure => present,
   }
 
-  sysctl::value { 'net.ipv4.forward':
+  sysctl::value { 'net.ipv4.ip_forward':
     value => 1,
   }
 
@@ -36,7 +36,7 @@ class protogalaxy::services (
       },
       Class['protogalaxy::disable_swap'],
       Kmod::Load['br_netfilter'],
-      Sysctl::Value['net.ipv4.forward'],
+      Sysctl::Value['net.ipv4.ip_forward'],
     ],
   }
 }

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -27,6 +27,10 @@ class protogalaxy::services (
     notify   => Service['containerd'],
   }
 
+  file { '/etc/crictl.yaml':
+    content => "runtime-endpoint: unix:///run/containerd/containerd.sock\nimage-endpoint: unix:///run/containerd/containerd.sock",
+  }
+
   service { 'containerd':
     ensure  => running,
     enable  => true,

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -22,6 +22,7 @@ class protogalaxy::services (
 
   exec { 'ensure containerd does not disable cri':
     command => 'rm /etc/containerd/config.toml',
+    provider => shell,
     onlyif  => 'grep \'disabled_plugins = \["cri"\]\' /etc/containerd/config.toml',
   }
 

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -35,8 +35,8 @@ class protogalaxy::services (
         false => Package['kubelet'],
       },
       Class['protogalaxy::disable_swap'],
-      kmod::load['br_netfilter'],
-      sysctl::value['net.ipv4.forward'],
+      Class['kmod::load::br_netfilter'],
+      Class['sysctl::value::net.ipv4.forward'],
     ],
   }
 }

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -35,8 +35,8 @@ class protogalaxy::services (
         false => Package['kubelet'],
       },
       Class['protogalaxy::disable_swap'],
-      Class['kmod::load::br_netfilter'],
-      Class['sysctl::value::net.ipv4.forward'],
+      Kmod::Load['br_netfilter'],
+      Sysctl::Value['net.ipv4.forward'],
     ],
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,10 @@
   "license": "Apache-2.0",
   "source": "https://github.com/LibreTexts/protogalaxy",
   "dependencies": [
-
+    {
+      "name": "camptocamp/kmod",
+      "version_requirement": "2.5.0"
+    }
   ],
   "operatingsystem_support": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,10 @@
     {
       "name": "camptocamp/kmod",
       "version_requirement": "2.5.0"
+    },
+    {
+      "name": "duritong/sysctl",
+      "version_requirement": "0.0.12"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Closes #2 and LibreTexts/metalc#208. This is already deployed in the galaxy dev cluster, but I want to run the setup through everyone just to make sure everyone is OK with it (and make sure everyone's OK with using containerd over CRI-O).